### PR TITLE
docs: change node.js version

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Node.js security CLI. The goal of the project is to a design a CLI that will all
 
 ## Requirements
 
-- [Node.js](https://nodejs.org/en/) version 10 or higher
+- [Node.js](https://nodejs.org/en/) version 12 or higher
 
 ## Getting Started
 


### PR DESCRIPTION
Due to use of Object.fromEntries like in `bin/index.js` line 38, the package need node.js v12 to be ran.